### PR TITLE
Tuteken patch 1

### DIFF
--- a/foobar2000.py
+++ b/foobar2000.py
@@ -33,7 +33,7 @@ class foobar2000(kp.Plugin):
 
     def __init__(self):
         super().__init__()
-        self._debug = False
+        self._debug = True
         self.dbg("CONSTRUCTOR")
         self.on_catalog()
 
@@ -61,7 +61,7 @@ class foobar2000(kp.Plugin):
 
     def on_execute(self, item, action):
         self.dbg("On execute (item {} : action {})".format(item, action))
-        command = "\"{}\" /{}".format(self.file_path, item.target())
+        command = "{} /{}".format(self.file_path, item.target())
         self.dbg(command)
         si = subprocess.STARTUPINFO()
         si.dwFlags = subprocess.STARTF_USESHOWWINDOW

--- a/foobar2000.py
+++ b/foobar2000.py
@@ -33,7 +33,7 @@ class foobar2000(kp.Plugin):
 
     def __init__(self):
         super().__init__()
-        self._debug = True
+        self._debug = False
         self.dbg("CONSTRUCTOR")
         self.on_catalog()
 


### PR DESCRIPTION
Originally the command that was executed to issue commands to foobar2000 had to be quoted as the variable from the configuration file would not include quotes.  That behavior has since changed, leading to two sets of quotes.  I have removed the step of adding quotes to the file path while building the command.  Everything appears to work again on version 2.18.2 of Keypirinha.

resolves #1 