### PR TITLE
Replace subprocess.call with kpu.shell_execute

### DIFF
--- a/foobar2000.py
+++ b/foobar2000.py
@@ -61,11 +61,9 @@ class foobar2000(kp.Plugin):
 
     def on_execute(self, item, action):
         self.dbg("On execute (item {} : action {})".format(item, action))
-        command = "{} /{}".format(self.file_path, item.target())
-        self.dbg(command)
-        si = subprocess.STARTUPINFO()
-        si.dwFlags = subprocess.STARTF_USESHOWWINDOW
-        subprocess.call(command, startupinfo=si)
+        args = "/{}".format(item.target())
+        self.dbg(self.file_path, args)
+        kpu.shell_execute(self.file_path, args)
 
     def _read_config(self):
         self.dbg("Read Config")


### PR DESCRIPTION
subprocess.call blocks the keypirinha executing thread when foobar2000
is launched, resulting a permanently green keypirinha icon in the tray.
kpu.shell_execute does not block in this case.